### PR TITLE
Add model method and content to Astronauts index page

### DIFF
--- a/app/models/astronaut.rb
+++ b/app/models/astronaut.rb
@@ -2,4 +2,8 @@ class Astronaut < ApplicationRecord
   validates_presence_of :name, :age, :job
   has_many :astronaut_missions
   has_many :missions, through: :astronaut_missions
+
+  def self.average_age
+    Astronaut.all.average(:age).to_f
+  end
 end

--- a/app/views/astronauts/index.html.erb
+++ b/app/views/astronauts/index.html.erb
@@ -1,5 +1,7 @@
 <h1> All Astronauts </h1>
 
+<h3><%= "Average Age of Astronauts is #{@astros.average_age}" %></h3>
+
 <% @astros.each do |astro| %>
   <b><%= astro.name %></b> <br>
   <%= astro.age %> <br>

--- a/spec/astronauts/index_spec.rb
+++ b/spec/astronauts/index_spec.rb
@@ -23,4 +23,23 @@ RSpec.describe 'Astronaut Index Page' do
     expect(page).to have_content(astro2.job)
     expect(page).to have_content(astro2.age)
   end
+
+  it "calculates the average age of all astronauts" do
+
+    astro1 = Astronaut.create!(
+      name: 'Neil Armstrong',
+      age: 37,
+      job: 'Commander'
+    )
+
+    astro2 = Astronaut.create!(
+      name: 'Nathan Keller',
+      age: 35,
+      job: 'Expo'
+    )
+
+    visit '/astronauts'
+
+    expect(page).to have_content("Average Age of Astronauts is 36.0")
+  end
 end

--- a/spec/models/astronaut_spec.rb
+++ b/spec/models/astronaut_spec.rb
@@ -11,4 +11,24 @@ describe Astronaut, type: :model do
     it { should have_many :astronaut_missions}
     it { should have_many :missions}
   end
+
+  describe 'Class Methods' do
+    it ".average_age" do
+      astro1 = Astronaut.create!(
+        name: 'Neil Armstrong',
+        age: 37,
+        job: 'Commander'
+      )
+
+      astro2 = Astronaut.create!(
+        name: 'Nathan Keller',
+        age: 35,
+        job: 'Expo'
+      )
+
+      astros = Astronaut.all
+
+      expect(astros.average_age).to eq(36.0)
+    end
+  end
 end


### PR DESCRIPTION
Astronauts can now calculate the average age of all astronauts in the database and this content is reflected on /astronauts (Astronauts Index page)